### PR TITLE
Add a Makefile to auto-build everything in a headless environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,8 @@ configure:
 	$(ECLIPSE_ANT) -f configure.xml $(CONFIGURE_FLAGS)
 
 build-plugins: configure
+	sh switch-build-command.sh sources/net.sf.j2s.ajax/.project \
+	  -net.sf.j2s.core.java2scriptbuilder +org.eclipse.jdt.core.javabuilder
 	set -e; for i in $(CORE_PLUGINS:%=sources/%); do \
 		( cd $$i && $(ECLIPSE_ANT_BUILD) $(CORE_FLAGS); ) \
 	done
@@ -64,6 +66,8 @@ local-install-plugins: build-plugins
 BADMETHOD1 = org/eclipse/jdt/internal/compiler/parser/TypeConverter.decodeType
 WORKAROUND1 = -vmargs -XX:CompileCommand=exclude,$(BADMETHOD1)
 build-libs: local-install-plugins
+	sh switch-build-command.sh sources/net.sf.j2s.ajax/.project \
+	  +net.sf.j2s.core.java2scriptbuilder -org.eclipse.jdt.core.javabuilder
 	test ! -f *err*.log
 	set -e; for i in $(CORE_J2SLIB); do \
 		$(ECLIPSE_J2S) -cmd build -path $$PWD/sources/$$i $(WORKAROUND1); \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,94 @@
+# To use this file, run:
+#
+# $ make CONFIGURE_FLAGS="-Dplugin.path=/path/to/your/eclipse/plugins"
+#
+# For example, on Debian GNU/Linux:
+#
+# $ make CONFIGURE_FLAGS="-Dplugin.path=/usr/lib/eclipse:/usr/share/eclipse/dropins/jdt"
+#
+# You can also add e.g. "-DforceContextQualifier=none" to make the jars be
+# output under a stable filename.
+#
+# Due to https://github.com/zhourenjian/java2script/issues/7 you may need to
+# run this using xvfb https://packages.debian.org/sid/xvfb
+#
+CONFIGURE_FLAGS +=
+CORE_FLAGS += -DjavacFailOnError=true
+INCUBATOR_FLAGS += -DjavacFailOnError=true -DjavacSource=1.6 -DjavacTarget=1.6
+
+# Order is important; dependencies must go earlier.
+CORE_PLUGINS = net.sf.j2s.core net.sf.j2s.ajax net.sf.j2s.ui net.sf.j2s.lib
+INCUBATOR_PLUGINS = net.sf.j2s.ui.template.velocity net.sf.j2s.ui.cmdline
+CORE_J2SLIB = net.sf.j2s.ajax net.sf.j2s.java.core net.sf.j2s.java.org.eclipse.swt
+
+BUILD_WORKSPACE := $(PWD)/autobuild
+ECLIPSE_AUTO = eclipse \
+	-configuration $(BUILD_WORKSPACE)/configuration \
+	-user $(BUILD_WORKSPACE) \
+	-data $(BUILD_WORKSPACE) \
+	-nosplash -clean
+
+ECLIPSE_ANT = $(ECLIPSE_AUTO) \
+	-application org.eclipse.ant.core.antRunner
+ECLIPSE_ANT_BUILD = $(ECLIPSE_ANT) build.update.jar
+ECLIPSE_ANT_CLEAN = if [ -f build.xml ]; then \
+	$(ECLIPSE_ANT) clean; \
+	rm -rf build.xml javaCompiler...args; \
+fi
+ECLIPSE_J2S = $(ECLIPSE_AUTO) \
+	-application net.sf.j2s.ui.cmdlineApi
+
+all: build-libs
+
+configure:
+	$(ECLIPSE_ANT) -f configure.xml $(CONFIGURE_FLAGS)
+
+build-plugins: configure
+	set -e; for i in $(CORE_PLUGINS:%=sources/%); do \
+		( cd $$i && $(ECLIPSE_ANT_BUILD) $(CORE_FLAGS); ) \
+	done
+	set -e; for i in $(INCUBATOR_PLUGINS:%=incubator/%); do \
+		( cd $$i && $(ECLIPSE_ANT_BUILD) $(INCUBATOR_FLAGS); ) \
+	done
+
+local-install-plugins: build-plugins
+	$(MAKE) DESTDIR=$(BUILD_WORKSPACE) eclipsedir= install-plugins
+	mkdir -p $(BUILD_WORKSPACE)/features
+	touch $(BUILD_WORKSPACE)/artifacts.xml
+	$(ECLIPSE_AUTO) -initialize
+
+build-libs: local-install-plugins
+	set -e; for i in $(CORE_J2SLIB); do \
+		$(ECLIPSE_J2S) -cmd build -path $$PWD/sources/$$i; \
+	done
+	mkdir -p sources/net.sf.j2s.lib/bin sources/net.sf.j2s.lib/j2slib
+	cd sources/net.sf.j2s.lib/bin && jar xf ../library.jar
+	cd sources/net.sf.j2s.lib && ant -f build/build.xml
+	cd sources/net.sf.j2s.lib && zip -r j2slib.zip j2slib
+
+clean:
+	for i in $(INCUBATOR_PLUGINS:%=incubator/%); do \
+		( cd $$i && $(ECLIPSE_ANT_CLEAN); ) \
+	done
+	for i in $(CORE_PLUGINS:%=sources/%); do \
+		( cd $$i && $(ECLIPSE_ANT_CLEAN); ) \
+	done
+	rm -rf $(BUILD_WORKSPACE)/.metadata
+
+prefix ?= /usr/local
+eclipsedir ?= $(prefix)/share/eclipse
+datadir ?= $(prefix)/share/java2script
+pluginsdir ?= $(eclipsedir)/plugins
+
+install-plugins:
+	test -z "$(DESTDIR)$(pluginsdir)" || mkdir -p "$(DESTDIR)$(pluginsdir)"
+	install -t "$(DESTDIR)$(pluginsdir)" \
+	  $(join $(CORE_PLUGINS:%=sources/%/),$(CORE_PLUGINS:%=%_2.0.0.jar)) \
+	  $(join $(INCUBATOR_PLUGINS:%=incubator/%/),$(INCUBATOR_PLUGINS:%=%_1.0.0.*.jar))
+
+install: install-plugins
+	test -z "$(DESTDIR)$(datadir)" || mkdir -p "$(DESTDIR)$(datadir)"
+	install -t "$(DESTDIR)$(datadir)" \
+	  sources/net.sf.j2s.lib/j2slib.zip
+
+.PHONY: all configure build-plugins local-install-plugins build-libs clean install-plugins install

--- a/configure.xml
+++ b/configure.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="java2script" default="configure" basedir=".">
+<!-- IMPORTANT!
+
+This is not a normal ant build file. You need to run it via the Eclipse
+AntRunner, like this Unix shell example:
+
+$ eclipse -nosplash -clean \
+  -configuration $PWD/autobuild/configuration \
+  -user $PWD/autobuild \
+  -data $PWD/autobuild \
+  -application org.eclipse.ant.core.antRunner \
+  -buildfile build.xml \
+  -Dplugin.path=/usr/lib/eclipse:/usr/share/eclipse/dropins/jdt
+
+Setting the -configuration, -user, and -data options are important in an
+automated build process where you don't want to clobber the default locations.
+
+For more details see http://help.eclipse.org/kepler/index.jsp?topic=%2Forg.eclipse.pde.doc.user%2Ftasks%2Fpde_feature_generating_antcommandline.htm
+-->
+<target name="configure">
+<eclipse.buildScript elements="plugin@net.sf.j2s.core"
+		buildDirectory="sources"
+		pluginPath="${plugin.path}"
+		forceContextQualifier="${forceContextQualifier}" />
+<eclipse.buildScript elements="plugin@net.sf.j2s.ajax"
+		buildDirectory="sources"
+		pluginPath="${plugin.path}"
+		forceContextQualifier="${forceContextQualifier}" />
+<eclipse.buildScript elements="plugin@net.sf.j2s.lib"
+		buildDirectory="sources"
+		pluginPath="${plugin.path}"
+		forceContextQualifier="${forceContextQualifier}" />
+<eclipse.buildScript elements="plugin@net.sf.j2s.ui"
+		buildDirectory="sources"
+		pluginPath="${plugin.path}"
+		forceContextQualifier="${forceContextQualifier}" />
+<eclipse.buildScript elements="plugin@net.sf.j2s.ui.template.velocity"
+		buildDirectory="incubator"
+		pluginPath="${plugin.path}${path.separator}sources"
+		forceContextQualifier="${forceContextQualifier}" />
+<eclipse.buildScript elements="plugin@net.sf.j2s.ui.cmdline"
+		buildDirectory="incubator"
+		pluginPath="${plugin.path}${path.separator}sources"
+		forceContextQualifier="${forceContextQualifier}" />
+</target>
+</project>

--- a/sources/net.sf.j2s.lib/build/build.xml
+++ b/sources/net.sf.j2s.lib/build/build.xml
@@ -39,7 +39,7 @@
          - - - - - - - - - - - - - - - - - -->
     <target name="j2s.pack.core">
     	<!-- This SmartJSCompressor will pack Class.js and ClassExt.js together -->
-        <java classname="net.sf.j2s.lib.build.SmartJSCompressor">
+        <java failonerror="true" classname="net.sf.j2s.lib.build.SmartJSCompressor">
     		<arg value="${j2s.core.src}/java/lang/Class.js"/>
         	<arg value="${j2s.core.bin}/java/lang/Class.js"/>
         	
@@ -52,7 +52,7 @@
         	</classpath>
        	</java>
 
-        <java classname="net.sf.j2s.lib.build.SmartJSCompressor">
+        <java failonerror="true" classname="net.sf.j2s.lib.build.SmartJSCompressor">
     		<arg value="${j2s.core.src}/java/lang/ClassLoader.js"/>
    			<arg value="${j2s.core.bin}/java/lang/ClassLoader.js"/>
         	
@@ -65,7 +65,7 @@
         	</classpath>
        	</java>
 
-        <java classname="net.sf.j2s.lib.build.SmartJSCompressor">
+        <java failonerror="true" classname="net.sf.j2s.lib.build.SmartJSCompressor">
     		<arg value="${j2s.core.src}/java/lang/ClassLoaderProgressMonitor.js"/>
    			<arg value="${j2s.core.bin}/java/lang/ClassLoaderProgressMonitor.js"/>
         	
@@ -78,7 +78,7 @@
         	</classpath>
        	</java>
     	
-        <java classname="net.sf.j2s.lib.build.SmartJSCompressor">
+        <java failonerror="true" classname="net.sf.j2s.lib.build.SmartJSCompressor">
     		<arg value="${j2s.core.src}/java/lang/Console.js"/>
     		<arg value="${j2s.core.bin}/java/lang/Console.js"/>
         	
@@ -90,7 +90,7 @@
         		<pathelement path="${j2s.lib.project}/bin"/>
         	</classpath>
        	</java>
-        <java classname="net.sf.j2s.lib.build.UTF8Concat">
+        <java failonerror="true" classname="net.sf.j2s.lib.build.UTF8Concat">
         	<arg value="none"/>
         	<arg value="${j2s.lib.dist}/j2slib.z.js"/>
         	
@@ -105,7 +105,7 @@
 	    		<pathelement path="${j2s.lib.project}/bin"/>
 	    	</classpath>
 	    </java>
-        <java classname="net.sf.j2s.lib.build.UTF8Concat">
+        <java failonerror="true" classname="net.sf.j2s.lib.build.UTF8Concat">
         	<arg value="none"/>
         	<arg value="${j2s.lib.dist}/j2slib.src.z.js"/>
         	
@@ -122,7 +122,7 @@
 	    	</classpath>
 	    </java>
 
-        <java classname="net.sf.j2s.lib.build.SmartJSCompressor">
+        <java failonerror="true" classname="net.sf.j2s.lib.build.SmartJSCompressor">
     		<arg value="${j2s.core.src}/java/package.js"/>
    			<arg value="${j2s.core.bin}/java/package.js"/>
         	
@@ -135,7 +135,7 @@
 
     	<mkdir dir="${j2s.core.bin}/org/eclipse/swt/"/>
 
-        <java classname="net.sf.j2s.lib.build.SmartJSCompressor">
+        <java failonerror="true" classname="net.sf.j2s.lib.build.SmartJSCompressor">
     		<arg value="${j2s.swt.bin}/org/eclipse/swt/package.js"/>
    			<arg value="${j2s.core.bin}/org/eclipse/swt/package.js"/>
         	
@@ -145,7 +145,7 @@
         		<pathelement path="${j2s.lib.project}/bin"/>
         	</classpath>
        	</java>
-        <java classname="net.sf.j2s.lib.build.UTF8Concat">
+        <java failonerror="true" classname="net.sf.j2s.lib.build.UTF8Concat">
         	<arg value="none"/>
         	<arg value="${j2s.lib.dist}/j2slib.swt.z.js"/>
         	
@@ -166,7 +166,7 @@
     	<!--<delete file="${j2s.core.bin}/org/eclipse/swt/package.js" quiet="true"/>-->
 
     	<!-- j2slibcore.z.js does not contains Console -->
-        <java classname="net.sf.j2s.lib.build.UTF8Concat">
+        <java failonerror="true" classname="net.sf.j2s.lib.build.UTF8Concat">
         	<arg value="none"/>
         	<arg value="${j2s.lib.dist}/j2slibcore.z.js"/>
         	
@@ -185,7 +185,7 @@
           target: j2s.pack.common                      
          - - - - - - - - - - - - - - - - - -->
     <target name="j2s.pack.common" depends="j2s.pack.prepare">
-        <java classname="net.sf.j2s.lib.build.J2SConcat">
+        <java failonerror="true" classname="net.sf.j2s.lib.build.J2SConcat">
         	<arg value="true"/>
         	<arg value="${j2s.core.bin}/java/core.z.js"/>
         	
@@ -375,7 +375,7 @@
         	</classpath>
         </java>
 
-        <java classname="net.sf.j2s.lib.build.UTF8Concat">
+        <java failonerror="true" classname="net.sf.j2s.lib.build.UTF8Concat">
         	<arg value="true"/>
         	<arg value="${j2s.core.bin}/org/apache/harmony/luni/util/Msg.z.js"/>
         	<arg value="${j2s.core.bin}"/>
@@ -387,7 +387,7 @@
 	    </java>
 
     	
-        <java classname="net.sf.j2s.lib.build.UTF8Concat">
+        <java failonerror="true" classname="net.sf.j2s.lib.build.UTF8Concat">
         	<arg value="true"/>
         	<arg value="${j2s.core.bin}/java/lang/StringBuilder.z.js"/>
         	<arg value="${j2s.core.bin}"/>
@@ -510,7 +510,7 @@
     	
     	<delete file="${j2s.ajax.bin}/net/sf/j2s/ajax/HttpRequest.js" quiet="true"/>
         	
-        <java classname="net.sf.j2s.lib.build.RegExCompress">
+        <java failonerror="true" classname="net.sf.j2s.lib.build.RegExCompress">
         	<arg value="false"/>
 
     		<arg value="${j2s.ajax.project}/j2sajax/HttpRequest.js"/>
@@ -543,7 +543,7 @@
           target: pack.swt.css                     
          - - - - - - - - - - - - - - - - - -->
     <target name="pack.swt.css">
-        <java classname="net.sf.j2s.lib.build.PackCSSIntoJS">
+        <java failonerror="true" classname="net.sf.j2s.lib.build.PackCSSIntoJS">
         	<arg value="${j2s.swt.bin}/"/>
         	
         	<classpath>
@@ -567,7 +567,7 @@
           target: pack.swt.basic              
          ================================= -->
     <target name="pack.swt.basic" description="Building j2s-swt-*.z.js">
-        <java classname="net.sf.j2s.lib.build.UTF8Concat">
+        <java failonerror="true" classname="net.sf.j2s.lib.build.UTF8Concat">
         	<arg value="true"/>
         	<arg value="${j2s.swt.bin}/org/eclipse/swt/basic.z.js"/>
         	
@@ -715,7 +715,7 @@
           target: pack.swt.more              
          ================================= -->
     <target name="pack.swt.more" description="Building j2s-swt-*.z.js">
-        <java classname="net.sf.j2s.lib.build.UTF8Concat">
+        <java failonerror="true" classname="net.sf.j2s.lib.build.UTF8Concat">
         	<arg value="true"/>
         	<arg value="${j2s.swt.bin}/org/eclipse/swt/widgets/more.z.js"/>
         	
@@ -746,7 +746,7 @@
 	    </java>
 
     	
-        <java classname="net.sf.j2s.lib.build.UTF8Concat">
+        <java failonerror="true" classname="net.sf.j2s.lib.build.UTF8Concat">
         	<arg value="true"/>
         	<arg value="${j2s.swt.bin}/org/eclipse/swt/SWT.z.js"/>
         	<arg value="${j2s.swt.bin}"/>
@@ -759,7 +759,7 @@
 	    	</classpath>
 	    </java>
     	
-        <java classname="net.sf.j2s.lib.build.UTF8Concat">
+        <java failonerror="true" classname="net.sf.j2s.lib.build.UTF8Concat">
         	<arg value="true"/>
         	<arg value="${j2s.swt.bin}/org/eclipse/swt/layout/RowLayout.z.js"/>
         	<arg value="${j2s.swt.bin}"/>
@@ -772,7 +772,7 @@
 	    </java>
 
     	
-        <java classname="net.sf.j2s.lib.build.UTF8Concat">
+        <java failonerror="true" classname="net.sf.j2s.lib.build.UTF8Concat">
         	<arg value="true"/>
         	<arg value="${j2s.swt.bin}/org/eclipse/swt/layout/FormLayout.z.js"/>
         	<arg value="${j2s.swt.bin}"/>
@@ -785,7 +785,7 @@
 	    	</classpath>
 	    </java>
     	
-        <java classname="net.sf.j2s.lib.build.UTF8Concat">
+        <java failonerror="true" classname="net.sf.j2s.lib.build.UTF8Concat">
         	<arg value="true"/>
         	<arg value="${j2s.swt.bin}/org/eclipse/swt/widgets/Tree.z.js"/>
         	<arg value="${j2s.swt.bin}"/>
@@ -799,7 +799,7 @@
 	    </java>
 
     	
-        <java classname="net.sf.j2s.lib.build.UTF8Concat">
+        <java failonerror="true" classname="net.sf.j2s.lib.build.UTF8Concat">
         	<arg value="true"/>
         	<arg value="${j2s.swt.bin}/org/eclipse/swt/widgets/ToolBar.z.js"/>
         	<arg value="${j2s.swt.bin}"/>
@@ -812,7 +812,7 @@
 	    </java>
 
     	
-        <java classname="net.sf.j2s.lib.build.UTF8Concat">
+        <java failonerror="true" classname="net.sf.j2s.lib.build.UTF8Concat">
         	<arg value="true"/>
         	<arg value="${j2s.swt.bin}/org/eclipse/swt/widgets/Table.z.js"/>
         	<arg value="${j2s.swt.bin}"/>
@@ -826,7 +826,7 @@
 	    	</classpath>
 	    </java>
 
-        <java classname="net.sf.j2s.lib.build.UTF8Concat">
+        <java failonerror="true" classname="net.sf.j2s.lib.build.UTF8Concat">
         	<arg value="true"/>
         	<arg value="${j2s.swt.bin}/org/eclipse/swt/custom/SashForm.z.js"/>
         	<arg value="${j2s.swt.bin}"/>
@@ -842,7 +842,7 @@
 	    </java>
 
 
-        <java classname="net.sf.j2s.lib.build.UTF8Concat">
+        <java failonerror="true" classname="net.sf.j2s.lib.build.UTF8Concat">
         	<arg value="true"/>
         	<arg value="${j2s.swt.bin}/org/eclipse/swt/custom/CTabFolder.z.js"/>
         	<arg value="${j2s.swt.bin}"/>
@@ -861,7 +861,7 @@
 	    </java>
 
     	
-        <java classname="net.sf.j2s.lib.build.UTF8Concat">
+        <java failonerror="true" classname="net.sf.j2s.lib.build.UTF8Concat">
         	<arg value="true"/>
         	<arg value="${j2s.swt.bin}/org/eclipse/swt/custom/CLabel.z.js"/>
         	<arg value="${j2s.swt.bin}"/>
@@ -874,7 +874,7 @@
 	    </java>
 
     	
-        <java classname="net.sf.j2s.lib.build.UTF8Concat">
+        <java failonerror="true" classname="net.sf.j2s.lib.build.UTF8Concat">
         	<arg value="true"/>
         	<arg value="${j2s.swt.bin}/org/eclipse/swt/custom/CBanner.z.js"/>
         	<arg value="${j2s.swt.bin}"/>
@@ -887,7 +887,7 @@
 	    </java>
 
     	
-        <java classname="net.sf.j2s.lib.build.UTF8Concat">
+        <java failonerror="true" classname="net.sf.j2s.lib.build.UTF8Concat">
         	<arg value="true"/>
         	<arg value="${j2s.swt.bin}/org/eclipse/swt/custom/ViewForm.z.js"/>
         	<arg value="${j2s.swt.bin}"/>
@@ -900,7 +900,7 @@
 	    </java>
 
 
-        <java classname="net.sf.j2s.lib.build.UTF8Concat">
+        <java failonerror="true" classname="net.sf.j2s.lib.build.UTF8Concat">
         	<arg value="true"/>
         	<arg value="${j2s.swt.bin}/org/eclipse/swt/widgets/Slider.z.js"/>
         	<arg value="${j2s.swt.bin}"/>
@@ -913,7 +913,7 @@
 	    </java>
 
     	
-        <java classname="net.sf.j2s.lib.build.UTF8Concat">
+        <java failonerror="true" classname="net.sf.j2s.lib.build.UTF8Concat">
         	<arg value="true"/>
         	<arg value="${j2s.swt.bin}/org/eclipse/swt/widgets/Scale.z.js"/>
         	<arg value="${j2s.swt.bin}"/>
@@ -925,7 +925,7 @@
 	    	</classpath>
 	    </java>
 
-        <java classname="net.sf.j2s.lib.build.UTF8Concat">
+        <java failonerror="true" classname="net.sf.j2s.lib.build.UTF8Concat">
         	<arg value="true"/>
         	<arg value="${j2s.swt.bin}/org/eclipse/swt/widgets/CoolBar.z.js"/>
         	<arg value="${j2s.swt.bin}"/>
@@ -938,7 +938,7 @@
 	    </java>
 
     	
-        <java classname="net.sf.j2s.lib.build.UTF8Concat">
+        <java failonerror="true" classname="net.sf.j2s.lib.build.UTF8Concat">
         	<arg value="true"/>
         	<arg value="${j2s.swt.bin}/org/eclipse/swt/graphics/Font.z.js"/>
         	<arg value="${j2s.swt.bin}"/>
@@ -959,7 +959,7 @@
           target: pack.swt.shell              
          ================================= -->
     <target name="pack.swt.shell" description="Building j2s-swt-*.z.js">
-        <java classname="net.sf.j2s.lib.build.UTF8Concat">
+        <java failonerror="true" classname="net.sf.j2s.lib.build.UTF8Concat">
         	<arg value="true"/>
         	<arg value="${j2s.swt.bin}/org/eclipse/swt/widgets/Shell.z.js"/>
         	
@@ -991,7 +991,7 @@
           target: pack.swt.dnd              
          ================================= -->
     <target name="pack.swt.dnd" description="Building j2s-swt-*.z.js">
-        <java classname="net.sf.j2s.lib.build.UTF8Concat">
+        <java failonerror="true" classname="net.sf.j2s.lib.build.UTF8Concat">
         	<arg value="true"/>
         	<arg value="${j2s.swt.bin}/org/eclipse/swt/dnd.z.js"/>
         	
@@ -1027,7 +1027,7 @@
           target: pack.jface.viewer             
          ================================= -->
     <target name="pack.jface.viewer" description="Building jface/viewers.interfaces.z.js">
-        <java classname="net.sf.j2s.lib.build.UTF8Concat">
+        <java failonerror="true" classname="net.sf.j2s.lib.build.UTF8Concat">
         	<arg value="false"/>
         	<arg value="${j2s.jface.bin}/org/eclipse/jface/viewers.interfaces.z.js"/>
         	
@@ -1081,7 +1081,7 @@
           target: pack.jface.resource             
          ================================= -->
     <target name="pack.jface.resource" description="Building jface/resource.z.js">
-        <java classname="net.sf.j2s.lib.build.UTF8Concat">
+        <java failonerror="true" classname="net.sf.j2s.lib.build.UTF8Concat">
         	<arg value="false"/>
         	<arg value="${j2s.jface.bin}/org/eclipse/jface/resource.z.js"/>
         	
@@ -1124,7 +1124,7 @@
           target: pack.jface.util             
          ================================= -->
     <target name="pack.jface.util" description="Building jface/util.z.js">
-        <java classname="net.sf.j2s.lib.build.UTF8Concat">
+        <java failonerror="true" classname="net.sf.j2s.lib.build.UTF8Concat">
         	<arg value="false"/>
         	<arg value="${j2s.jface.bin}/org/eclipse/jface/util.z.js"/>
         	
@@ -1151,7 +1151,7 @@
           target: pack.jface.window             
          ================================= -->
     <target name="pack.jface.window" description="Building jface/window.z.js">
-        <java classname="net.sf.j2s.lib.build.UTF8Concat">
+        <java failonerror="true" classname="net.sf.j2s.lib.build.UTF8Concat">
         	<arg value="false"/>
         	<arg value="${j2s.jface.bin}/org/eclipse/jface/window.z.js"/>
         	

--- a/sources/net.sf.j2s.lib/src/net/sf/j2s/lib/build/UTF8Concat.java
+++ b/sources/net.sf.j2s.lib/src/net/sf/j2s/lib/build/UTF8Concat.java
@@ -79,7 +79,7 @@ public class UTF8Concat {
 				//*/
 			} catch (FileNotFoundException e) {
 				e.printStackTrace();
-				return;
+				System.exit(1);
 			}
 		}
 		try {
@@ -98,6 +98,7 @@ public class UTF8Concat {
 			fos.close();
 		} catch (IOException e) {
 			e.printStackTrace();
+			System.exit(1);
 		}
 
 	}

--- a/switch-build-command.sh
+++ b/switch-build-command.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -e
+
+enable() {
+perl -0 -p \
+	-e 's|<!--\s*(<buildCommand>\s*<name>'"$1"'</name>.*?</buildCommand>\s*)\n\s*-->|\1|gs'
+}
+
+disable() {
+perl -0 -p \
+	-e 's|\n((\s*)<buildCommand>\s*<name>'"$1"'</name>.*?\n(\s*)</buildCommand>.*?\n)|\n\2<!--\n\1\3-->\n|sg' \
+| perl -0 -p \
+	-e 's|<!--\s*(<!--\s*<buildCommand>\s*<name>'"$1"'</name>.*?</buildCommand>\s*-->)\s*-->|\1|gs'
+}
+
+file="$1"
+shift
+
+while [ -n "$1" ]; do
+case "$1" in
++*) cmd=enable;name="${1#+}";;
+-*) cmd=disable;name="${1#-}";;
+*) false;;
+esac
+echo "$cmd" "$name"
+sed -e 's/\r$//g' "$file" | $cmd "$name" | sed -e 's/$/\r/g' > "$file.tmp"
+mv "$file.tmp" "$file"
+shift
+done


### PR DESCRIPTION
This makes it easier to package this tool for Debian, which must build everything from source automatically.

I am making this PR against the 3.8 branch since that is what Debian uses, but the script probably also works for the master branch.
