### PR TITLE
Bug: 'The method flatten ... is not applicable for the arguments ...'

### DIFF
--- a/sources/net.sf.j2s.java.core/src/java/util/stream/ReferencePipeline.java
+++ b/sources/net.sf.j2s.java.core/src/java/util/stream/ReferencePipeline.java
@@ -435,8 +435,11 @@ abstract class ReferencePipeline<P_IN, P_OUT>
         // super type of U an ArrayStoreException will be thrown.
         @SuppressWarnings("rawtypes")
         IntFunction rawGenerator = (IntFunction) generator;
-        return (A[]) Nodes.flatten(evaluateToArrayNode(rawGenerator), rawGenerator)
-                              .asArray(rawGenerator);
+        // using extra temporary variable 'node' with explicit type 'Node<A>' required as Eclipse 4.7.3a reports error
+        // 'The method flatten(Node<T>, IntFunction<T[]>) in the type Nodes is not applicable for the arguments (Node, IntFunction)'
+        // when directly using 'evaluateToArrayNode(rawGenerator)' in call to 'Nodes.flatten'. 
+        Node<A> node = evaluateToArrayNode(rawGenerator); 
+        return (A[]) Nodes.flatten(node, rawGenerator).asArray(rawGenerator);
     }
 
     @Override


### PR DESCRIPTION
Eclipse 4.7.3a reports Java problem:

    'The method flatten(Node<T>, IntFunction<T[]>) in the type Nodes is not
     applicable for the arguments (Node, IntFunction)'

when compiling ReferencePipeline.java.

Cause
=====

It looks like the compiler cannot correctly infer the (generic) types
of the method calls in the argument list of flatten.

Solution
========

Introduce an extra temporary variable 'node' with explicit type 'Node<A>'
holding the value of the expression originally passed to flatten. This
way the correct types are used in the method call and the error message
disappears.